### PR TITLE
security(helm): avoid passing secrets directly into statefulset

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# For more information, please refer to: https://editorconfig.org
+root = true
+
+[*]
+end_of_line = lf
+insert_final_newline = true
+charset = utf-8
+indent_style = space
+indent_size = 2
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/helm/wg-easy/Chart.yaml
+++ b/helm/wg-easy/Chart.yaml
@@ -4,13 +4,13 @@ description: Wireguard Easy helm chart for Kubernetes
 home: https://github.com/hansehe/wg-easy-helm
 icon: https://raw.githubusercontent.com/hansehe/wg-easy-helm/master/helm/wireguard.png
 keywords:
-- wireguard
-- wg-easy
+  - wireguard
+  - wg-easy
 maintainers:
-- email: hans.erik.heggem@gmail.com
-  name: hansehe
+  - email: hans.erik.heggem@gmail.com
+    name: hansehe
 sources:
-- https://github.com/hansehe/wg-easy-helm
+  - https://github.com/hansehe/wg-easy-helm
 
 # A chart can be either an 'application' or a 'library' chart.
 #
@@ -24,7 +24,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.0
+version: 0.1.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/wg-easy/templates/secret.yaml
+++ b/helm/wg-easy/templates/secret.yaml
@@ -1,0 +1,20 @@
+{{- if .Values.enabled }}
+{{- if .Values.secret.create }}
+apiVersion: v1
+kind: Secret
+metadata:
+  {{- if .Values.secret.name }}
+  name: {{ .Values.secret.name }}
+  {{- else }}
+  name: {{ include "wg-easy.fullname" . }}
+  {{- end }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "wg-easy.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- range $key, $value := .Values.environmentVariables }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}
+{{- end }}
+{{- end }}

--- a/helm/wg-easy/templates/statefulset.yaml
+++ b/helm/wg-easy/templates/statefulset.yaml
@@ -64,10 +64,6 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-          {{- range $key, $value := .Values.environmentVariables }}
-          - name: {{ $key }}
-            value: {{ $value | quote }}
-          {{- end }}
           {{- if .Values.enableHttpOpenTelemetryCollector }}
           - name: COLLECTOR_OTLP_ENABLED
             value: "true"
@@ -76,6 +72,13 @@ spec:
           - name: COLLECTOR_ZIPKIN_HOST_PORT
             value: ":9411"
           {{- end }}
+          envFrom:
+            - secretRef:
+                {{- if .Values.secret.name }}
+                name: {{ .Values.secret.name }}
+                {{- else }}
+                name: {{ include "wg-easy.fullname" . }}
+                {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/wg-easy/values.yaml
+++ b/helm/wg-easy/values.yaml
@@ -16,14 +16,25 @@ nameOverride: ""
 fullnameOverride: ""
 terminationGracePeriodSeconds: 10
 environmentVariables:
-  WG_HOST: localhost # WAN IP, or a Dynamic DNS hostname.
-  PASSWORD: password # Password for the UI.
+  # WAN IP or a Dynamic DNS hostname.
+  WG_HOST: localhost
+  # Password for the UI.
+  PASSWORD: password
 
 serviceAccount:
   # Specifies whether a service account should be created
   create: true
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
+  name:
+
+secret:
+  # Create a secret to store the environment variables. Disabling this
+  # and setting a secret name allows users to bring their own secret
+  # via the external-secrets-operator or similar. 
+  create: true
+  # The name of the secret to use.
+  # If not set and create is true, a name is generated using the fullname template.
   name:
 
 podAnnotations: {}


### PR DESCRIPTION
This ensures that secrets are stored in a Kubernetes `Secret`, which are often specifically protected via RBAC. The new setup also allows users to bring their own secret, which enables the use of secret management via the [`external-secrets-operator`](https://external-secrets.io/latest/)  or similar.

I also added the `.editorconfig`  to force an indentation level of 2 spaces to avoid issues for future contributors.

<details>
<summary><code>diff -u master.yaml pr.yaml </code></summary>

```diff
--- master.yaml 2025-03-22 22:09:07.005295053 +0100
+++ pr.yaml     2025-03-22 22:09:16.835305683 +0100
@@ -7,12 +7,29 @@
   namespace: kube-system
   labels:
 
-    helm.sh/chart: wg-easy-0.1.0
+    helm.sh/chart: wg-easy-0.1.1
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: wg-easy/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-wg-easy
+  namespace: kube-system
+  labels:
+    helm.sh/chart: wg-easy-0.1.1
+    app.kubernetes.io/name: wg-easy
+    app.kubernetes.io/instance: release
+    app.kubernetes.io/version: "9"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:
+  PASSWORD: "password"
+  WG_HOST: "localhost"
+---
 # Source: wg-easy/templates/wg-easy-volume.yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -35,7 +52,7 @@
   name: release-wg-easy-headless
   namespace: kube-system
   labels:
-    helm.sh/chart: wg-easy-0.1.0
+    helm.sh/chart: wg-easy-0.1.1
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -62,7 +79,7 @@
   name: release-wg-easy
   namespace: kube-system
   labels:
-    helm.sh/chart: wg-easy-0.1.0
+    helm.sh/chart: wg-easy-0.1.1
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -92,7 +109,7 @@
   name: release-wg-easy
   namespace: kube-system
   labels:
-    helm.sh/chart: wg-easy-0.1.0
+    helm.sh/chart: wg-easy-0.1.1
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -148,10 +165,9 @@
           resources:
             {}
           env:
-          - name: PASSWORD
-            value: "password"
-          - name: WG_HOST
-            value: "localhost"
+          envFrom:
+            - secretRef:
+                name: release-wg-easy
 ---
 # Source: wg-easy/templates/tests/test-connection.yaml
 apiVersion: v1
@@ -160,7 +176,7 @@
   name: "release-wg-easy-test-connection"
   labels:
 
-    helm.sh/chart: wg-easy-0.1.0
+    helm.sh/chart: wg-easy-0.1.1
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
```

</details>