### PR TITLE
fix(secret): allow users to bring external secret

### DIFF
--- a/helm/wg-easy/Chart.yaml
+++ b/helm/wg-easy/Chart.yaml
@@ -24,7 +24,7 @@ type: application
 
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 0.1.1
+version: 0.1.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application.

--- a/helm/wg-easy/templates/serviceaccount.yaml
+++ b/helm/wg-easy/templates/serviceaccount.yaml
@@ -6,6 +6,6 @@ metadata:
   name: {{ include "wg-easy.serviceAccountName" . }}
   namespace: {{ .Release.Namespace }}
   labels:
-{{ include "wg-easy.labels" . | nindent 4 }}
+    {{- include "wg-easy.labels" . | nindent 4 }}
 {{- end -}}
 {{- end }}

--- a/helm/wg-easy/templates/statefulset.yaml
+++ b/helm/wg-easy/templates/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-          {{ $useSecret := or .Values.secret.create (ne .Values.secret.name "") }}
+          {{ $useSecret := or .Values.secret.create .Values.secret.name }}
           {{- if not $useSecret }}
           {{- range $key, $value := .Values.environmentVariables }}
           - name: {{ $key }}

--- a/helm/wg-easy/templates/statefulset.yaml
+++ b/helm/wg-easy/templates/statefulset.yaml
@@ -64,7 +64,7 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-          {{ $useSecret := or .Values.secret.create .Values.secret.name }}
+          {{- $useSecret := or .Values.secret.create .Values.secret.name }}
           {{- if not $useSecret }}
           {{- range $key, $value := .Values.environmentVariables }}
           - name: {{ $key }}

--- a/helm/wg-easy/templates/statefulset.yaml
+++ b/helm/wg-easy/templates/statefulset.yaml
@@ -64,7 +64,8 @@ spec:
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           env:
-          {{- if not .Values.secret.create }}
+          {{ $useSecret := or .Values.secret.create (ne .Values.secret.name "") }}
+          {{- if not $useSecret }}
           {{- range $key, $value := .Values.environmentVariables }}
           - name: {{ $key }}
             value: {{ $value | quote }}
@@ -73,12 +74,12 @@ spec:
           {{- if .Values.enableHttpOpenTelemetryCollector }}
           - name: COLLECTOR_OTLP_ENABLED
             value: "true"
-          {{- end }}  
+          {{- end }}
           {{- if .Values.enableHttpZipkinCollector }}
           - name: COLLECTOR_ZIPKIN_HOST_PORT
             value: ":9411"
           {{- end }}
-          {{- if .Values.secret.create }}
+          {{- if $useSecret }}
           envFrom:
             - secretRef:
                 {{- if .Values.secret.name }}

--- a/helm/wg-easy/templates/tests/test-connection.yaml
+++ b/helm/wg-easy/templates/tests/test-connection.yaml
@@ -4,7 +4,7 @@ kind: Pod
 metadata:
   name: "{{ include "wg-easy.fullname" . }}-test-connection"
   labels:
-{{ include "wg-easy.labels" . | nindent 4 }}
+    {{- include "wg-easy.labels" . | nindent 4 }}
   annotations:
     "helm.sh/hook": test-success
 spec:


### PR DESCRIPTION
This allows users to reference a secret that has not been created by this helm chart, while still keeping the default behaviour.

### Remove unnecessary new line

<details>
<summary>
<code>helm template release helm/wg-easy</code>
</summary>

```diff
--- master.out.yaml     2025-03-27 23:22:57.772215915 +0100
+++ default.out.yaml    2025-03-27 23:35:54.289724327 +0100
@@ -6,8 +6,7 @@
   name: release-wg-easy
   namespace: kube-system
   labels:
-
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -35,7 +34,7 @@
   name: release-wg-easy-headless
   namespace: kube-system
   labels:
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -62,7 +61,7 @@
   name: release-wg-easy
   namespace: kube-system
   labels:
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -92,7 +91,7 @@
   name: release-wg-easy
   namespace: kube-system
   labels:
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -159,8 +158,7 @@
 metadata:
   name: "release-wg-easy-test-connection"
   labels:
-
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
```
</details>

### Enable usage of secret created by chart

<details>
<summary>
<code>helm template release helm/wg-easy --set secret.create=true</code>
</summary>

```diff
--- master.out.yaml     2025-03-27 23:22:57.772215915 +0100
+++ secret.out.yaml     2025-03-27 23:35:49.126714923 +0100
@@ -6,13 +6,29 @@
   name: release-wg-easy
   namespace: kube-system
   labels:
-
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
     app.kubernetes.io/managed-by: Helm
 ---
+# Source: wg-easy/templates/secret.yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: release-wg-easy
+  namespace: kube-system
+  labels:
+    helm.sh/chart: wg-easy-0.1.2
+    app.kubernetes.io/name: wg-easy
+    app.kubernetes.io/instance: release
+    app.kubernetes.io/version: "9"
+    app.kubernetes.io/managed-by: Helm
+type: Opaque
+stringData:
+  PASSWORD: "password"
+  WG_HOST: "localhost"
+---
 # Source: wg-easy/templates/wg-easy-volume.yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -35,7 +51,7 @@
   name: release-wg-easy-headless
   namespace: kube-system
   labels:
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -62,7 +78,7 @@
   name: release-wg-easy
   namespace: kube-system
   labels:
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -92,7 +108,7 @@
   name: release-wg-easy
   namespace: kube-system
   labels:
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -148,10 +164,9 @@
           resources:
             {}
           env:
-          - name: PASSWORD
-            value: "password"
-          - name: WG_HOST
-            value: "localhost"
+          envFrom:
+            - secretRef:
+                name: release-wg-easy
 ---
 # Source: wg-easy/templates/tests/test-connection.yaml
 apiVersion: v1
@@ -159,8 +174,7 @@
 metadata:
   name: "release-wg-easy-test-connection"
   labels:
-
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
```
</details>

### Use existing secret provided by external mechanism

<details>
<summary>
<code>helm template release helm/wg-easy --set secret.name="my-external-secret"</code>
</summary>

```diff
--- master.out.yaml     2025-03-27 23:22:57.772215915 +0100
+++ external.out.yaml   2025-03-27 23:35:52.094720335 +0100
@@ -6,8 +6,7 @@
   name: release-wg-easy
   namespace: kube-system
   labels:
-
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -35,7 +34,7 @@
   name: release-wg-easy-headless
   namespace: kube-system
   labels:
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -62,7 +61,7 @@
   name: release-wg-easy
   namespace: kube-system
   labels:
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -92,7 +91,7 @@
   name: release-wg-easy
   namespace: kube-system
   labels:
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
@@ -148,10 +147,9 @@
           resources:
             {}
           env:
-          - name: PASSWORD
-            value: "password"
-          - name: WG_HOST
-            value: "localhost"
+          envFrom:
+            - secretRef:
+                name: my-external-secret
 ---
 # Source: wg-easy/templates/tests/test-connection.yaml
 apiVersion: v1
@@ -159,8 +157,7 @@
 metadata:
   name: "release-wg-easy-test-connection"
   labels:
-
-    helm.sh/chart: wg-easy-0.1.1
+    helm.sh/chart: wg-easy-0.1.2
     app.kubernetes.io/name: wg-easy
     app.kubernetes.io/instance: release
     app.kubernetes.io/version: "9"
```
</details>
