### PR TITLE
feat: added field to override command on the image

### DIFF
--- a/helm/wg-easy/templates/statefulset.yaml
+++ b/helm/wg-easy/templates/statefulset.yaml
@@ -41,6 +41,9 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ include "wg-easy.wg-easyVersion" . }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.command }}
+          command: {{ toYaml .Values.command | nindent 12 }}
+          {{- end }}
           ports:
             - name: udp-vpn
               containerPort: 51820

--- a/helm/wg-easy/values.yaml
+++ b/helm/wg-easy/values.yaml
@@ -10,6 +10,18 @@ image:
   pullPolicy: IfNotPresent
   versionOverride: "*"
 
+# This will enable IP forwarding and NAT masquerading
+# This is required for the VPN to work in full tunnel mode
+# command:
+#   - /bin/sh
+#   - -c
+#   - |
+#     echo "Enabling IP forwarding"
+#     sysctl -w net.ipv4.ip_forward=1
+#     iptables -t nat -F POSTROUTING
+#     iptables -t nat -A POSTROUTING -s 10.8.0.0/24 -o eth0 -j MASQUERADE
+#     exec node server.js
+
 healthCheckUrl: /
 imagePullSecrets: []
 nameOverride: ""
@@ -43,6 +55,8 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 securityContext:
+  privileged: true
+  allowPrivilegeEscalation: true
   capabilities:
     add:
       - NET_ADMIN


### PR DESCRIPTION
### Add support for overriding container command via values.yaml

This PR adds support for customizing the container's startup command in the Helm chart using the `command` field in `values.yaml`.

This allows users to:
- Enable IP forwarding and iptables rules for VPN traffic
- Run custom scripts before launching `wg-easy`

NOTE: If `command` is not set, the default command defined by the container image is used.
